### PR TITLE
Fix compatibility with rebase 1.11

### DIFF
--- a/conflicts-test/Main/Statements.hs
+++ b/conflicts-test/Main/Statements.hs
@@ -1,6 +1,7 @@
 module Main.Statements where
 
 import Rebase.Prelude
+import Contravariant.Extras
 import Hasql.Statement
 import qualified Hasql.Encoders as E
 import qualified Hasql.Decoders as D

--- a/hasql-transaction.cabal
+++ b/hasql-transaction.cabal
@@ -54,6 +54,7 @@ test-suite conflicts-test
     -threaded
     "-with-rtsopts=-N"
   build-depends:
+    contravariant-extras >=0.3 && <0.4,
     hasql-transaction,
     hasql,
     async >=2.1 && <3,


### PR DESCRIPTION
Fixes the following build failure:

```
Building test suite 'conflicts-test' for hasql-transaction-1.0.0.1..
[1 of 3] Compiling Main.Statements  ( conflicts-test/Main/Statements.hs, dist/build/conflicts-test/conflicts-test-tmp/Main/Statements.dyn_o )

conflicts-test/Main/Statements.hs:36:6: error:
    • Variable not in scope:
        contrazip2
          :: E.Params Int64
             -> E.Params Scientific -> E.Params (Int64, Scientific)
    • Perhaps you meant ‘contramap’ (imported from Rebase.Prelude)
   |
36 |     (contrazip2 ((E.param . E.nonNullable) E.int8) ((E.param . E.nonNullable) E.numeric))
   |      ^^^^^^^^^^
```