### PR TITLE
Add function to execute transactions with optional prepared statements on TCL commands

### DIFF
--- a/library/Hasql/Transaction/Private/Sessions.hs
+++ b/library/Hasql/Transaction/Private/Sessions.hs
@@ -12,31 +12,31 @@ We may want to
 do one transaction retry in case of the 23505 error, and fail if an identical
 error is seen.
 -}
-inRetryingTransaction :: IsolationLevel -> Mode -> Session (a, Bool) -> Session a
-inRetryingTransaction level mode session =
+inRetryingTransaction :: IsolationLevel -> Mode -> Session (a, Bool) -> Bool -> Session a
+inRetryingTransaction level mode session preparable =
   fix $ \ retry -> do
-    attemptRes <- tryTransaction level mode session
+    attemptRes <- tryTransaction level mode session preparable
     case attemptRes of
       Just a -> return a
       Nothing -> retry
 
-tryTransaction :: IsolationLevel -> Mode -> Session (a, Bool) -> Session (Maybe a)
-tryTransaction level mode body = do
+tryTransaction :: IsolationLevel -> Mode -> Session (a, Bool) -> Bool -> Session (Maybe a)
+tryTransaction level mode body preparable = do
 
-  statement () (Statements.beginTransaction level mode)
+  statement () (Statements.beginTransaction level mode preparable)
 
   bodyRes <- catchError (fmap Just body) $ \ error -> do
-    statement () Statements.abortTransaction
+    statement () (Statements.abortTransaction preparable)
     handleTransactionError error $ return Nothing
 
   case bodyRes of
-    Just (res, commit) -> catchError (commitOrAbort commit $> Just res) $ \ error -> do
+    Just (res, commit) -> catchError (commitOrAbort commit preparable $> Just res) $ \ error -> do
       handleTransactionError error $ return Nothing
     Nothing -> return Nothing
 
-commitOrAbort commit = if commit
-  then statement () Statements.commitTransaction
-  else statement () Statements.abortTransaction
+commitOrAbort commit preparable = if commit
+  then statement () (Statements.commitTransaction preparable)
+  else statement () (Statements.abortTransaction preparable)
 
 handleTransactionError error onTransactionError = case error of
   QueryError _ _ (ResultError (ServerError "40001" _ _ _)) -> onTransactionError

--- a/library/Hasql/Transaction/Private/Statements.hs
+++ b/library/Hasql/Transaction/Private/Statements.hs
@@ -12,17 +12,17 @@ import qualified Hasql.Transaction.Private.SQL as D
 -- * Transactions
 -------------------------
 
-beginTransaction :: IsolationLevel -> Mode -> A.Statement () ()
-beginTransaction isolation mode =
-  A.Statement (D.beginTransaction isolation mode) B.noParams C.noResult True
+beginTransaction :: IsolationLevel -> Mode -> Bool -> A.Statement () ()
+beginTransaction isolation mode preparable =
+  A.Statement (D.beginTransaction isolation mode) B.noParams C.noResult preparable
 
-commitTransaction :: A.Statement () ()
-commitTransaction =
-  A.Statement "COMMIT" B.noParams C.noResult True
+commitTransaction :: Bool -> A.Statement () ()
+commitTransaction preparable =
+  A.Statement "COMMIT" B.noParams C.noResult preparable
 
-abortTransaction :: A.Statement () ()
-abortTransaction =
-  A.Statement "ABORT" B.noParams C.noResult True
+abortTransaction :: Bool -> A.Statement () ()
+abortTransaction preparable =
+  A.Statement "ABORT" B.noParams C.noResult preparable
 
 
 -- * Streaming

--- a/library/Hasql/Transaction/Private/Transaction.hs
+++ b/library/Hasql/Transaction/Private/Transaction.hs
@@ -29,9 +29,9 @@ instance Monoid a => Monoid (Transaction a) where
 -- |
 -- Execute the transaction using the provided isolation level and mode.
 {-# INLINE run #-}
-run :: Transaction a -> IsolationLevel -> Mode -> B.Session a
-run (Transaction session) isolation mode =
-  D.inRetryingTransaction isolation mode (runStateT session True)
+run :: Transaction a -> IsolationLevel -> Mode -> Bool -> B.Session a
+run (Transaction session) isolation mode preparable =
+  D.inRetryingTransaction isolation mode (runStateT session True) preparable
 
 -- |
 -- Possibly a multi-statement query,

--- a/library/Hasql/Transaction/Sessions.hs
+++ b/library/Hasql/Transaction/Sessions.hs
@@ -1,12 +1,14 @@
 module Hasql.Transaction.Sessions
 (
   transaction,
+  transactionPreparable,
   -- * Transaction settings
   C.Mode(..),
   C.IsolationLevel(..),
 )
 where
 
+import Data.Bool
 import qualified Hasql.Transaction.Private.Transaction as A
 import qualified Hasql.Session as B
 import qualified Hasql.Transaction.Private.Model as C
@@ -17,4 +19,14 @@ import qualified Hasql.Transaction.Private.Model as C
 {-# INLINE transaction #-}
 transaction :: C.IsolationLevel -> C.Mode -> A.Transaction a -> B.Session a
 transaction isolation mode transaction =
-  A.run transaction isolation mode
+  A.run transaction isolation mode True
+
+-- |
+-- Execute the transaction using the provided isolation level and mode,
+-- and specifying if the BEGIN, COMMIT and ABORT statements should be prepared or not.
+--
+-- Helps with transaction pooling due to its incompatibility with prepared statements.
+{-# INLINE transactionPreparable #-}
+transactionPreparable :: C.IsolationLevel -> C.Mode -> A.Transaction a -> Bool -> B.Session a
+transactionPreparable isolation mode transaction preparable =
+  A.run transaction isolation mode preparable


### PR DESCRIPTION
Closes #15

As it was mentioned in the issue, we need an option where no statements are prepared in order to work nicely with transaction poolers.

My solution is to add a `transactionPreparable` function. It has a boolean parameter that specifies if the commands for transaction control should be executed in a prepared or unprepared statement.