### PR TITLE
Remove contravariant extras

### DIFF
--- a/conflicts-test/Main/Statements.hs
+++ b/conflicts-test/Main/Statements.hs
@@ -1,6 +1,5 @@
 module Main.Statements where
 
-import Contravariant.Extras
 import Hasql.Decoders qualified as D
 import Hasql.Encoders qualified as E
 import Hasql.Statement
@@ -33,7 +32,7 @@ modifyBalance :: Statement (Int64, Scientific) Bool
 modifyBalance =
   Statement
     "update account set balance = balance + $2 where id = $1"
-    (contrazip2 ((E.param . E.nonNullable) E.int8) ((E.param . E.nonNullable) E.numeric))
+    ((fst >$< (E.param . E.nonNullable) E.int8) <> (snd >$< (E.param . E.nonNullable) E.numeric))
     (fmap (> 0) D.rowsAffected)
     True
 

--- a/hasql-transaction.cabal
+++ b/hasql-transaction.cabal
@@ -95,7 +95,6 @@ library
     bytestring >=0.10 && <0.13,
     bytestring-tree-builder >=0.2.7.8 && <0.3,
     contravariant >=1.3 && <2,
-    contravariant-extras >=0.3 && <0.4,
     hasql >=1.7 && <1.8,
     mtl >=2.2 && <3,
     transformers >=0.5 && <0.7,

--- a/hasql-transaction.cabal
+++ b/hasql-transaction.cabal
@@ -115,7 +115,6 @@ test-suite conflicts-test
 
   build-depends:
     async >=2.1 && <3,
-    contravariant-extras >=0.3 && <0.4,
     hasql,
     hasql-transaction,
     rerebase >=1.11 && <2,

--- a/library/Hasql/Transaction/Private/Prelude.hs
+++ b/library/Hasql/Transaction/Private/Prelude.hs
@@ -4,7 +4,6 @@ module Hasql.Transaction.Private.Prelude
   )
 where
 
-import Contravariant.Extras as Exports
 import Control.Applicative as Exports
 import Control.Arrow as Exports
 import Control.Category as Exports

--- a/library/Hasql/Transaction/Private/Statements.hs
+++ b/library/Hasql/Transaction/Private/Statements.hs
@@ -38,8 +38,7 @@ fetchFromCursor step init rowDec =
     sql =
       "FETCH FORWARD $1 FROM $2"
     encoder =
-      contrazip2
-        ((B.param . B.nonNullable) B.int8)
-        ((B.param . B.nonNullable) B.bytea)
+      (fst >$< (B.param . B.nonNullable) B.int8) <>
+      (snd >$< (B.param . B.nonNullable) B.bytea)
     decoder =
       C.foldlRows step init rowDec


### PR DESCRIPTION
As discussed in https://github.com/nikita-volkov/hasql/issues/163.

The second commit, dropping the dep from test dependencies, is not strictly necessary - happy to drop that commit, if you wish. Just thought it made sense for consistency.